### PR TITLE
[Fix] Fixed the required projects count for UNIX section of RNCP-7 Sec

### DIFF
--- a/angular/src/assets/7-sec.json
+++ b/angular/src/assets/7-sec.json
@@ -91,7 +91,7 @@
     "id": 3,
     "name": "UNIX",
     "min_xp": 30000,
-    "min_projects": 3,
+    "min_projects": 2,
     "projects": [
       {
         "id": 1467,


### PR DESCRIPTION
As seen on the intranet, only `2 projects` are required in the UNIX section:
![image](https://github.com/d-r-e/rncp/assets/9162303/cb1d61ed-8833-4419-958a-dce92b7f3e75)
