### PR TITLE
[Fix] Removed mandatory for RNCP-7 AI

### DIFF
--- a/angular/src/assets/7-ai.json
+++ b/angular/src/assets/7-ai.json
@@ -202,18 +202,5 @@
 				"xp": null
 			}
 		]
-	},
-	{
-		"id": 1,
-		"name": "blocks.mandatory",
-		"min_projects": 1,
-		"min_xp": 0,
-		"projects": [
-			{
-				"id": 1460,
-				"name": "Total perspective vortex",
-				"xp": null
-			}
-		]
 	}
 ]


### PR DESCRIPTION
Some students came to me asking why there is a mandatory project for the RNCP-7 AI. 
So, I checked the intra and there is not.
I removed it in this PR.

Sources (french sorry):
![image](https://github.com/d-r-e/rncp/assets/9162303/bde4bbba-21c7-4bfa-88c4-4cf8d0cd53f0)
![image](https://github.com/d-r-e/rncp/assets/9162303/93ef42b2-781e-4a23-b899-b51619666834)
