### PR TITLE
[Fix] Change incorrect project ids in JSON files

### DIFF
--- a/angular/src/assets/7-ai.json
+++ b/angular/src/assets/7-ai.json
@@ -142,22 +142,22 @@
 				"xp": null
 			},
 			{
-				"id": 1407,
+				"id": 1400,
 				"name": "ft_nmap",
 				"xp": null
 			},
 			{
-				"id": 2080,
+				"id": 1854,
 				"name": "42sh",
 				"xp": null
 			},
 			{
-				"id": 2082,
+				"id": 1458,
 				"name": "DoomNukem",
 				"xp": null
 			},
 			{
-				"id": 2083,
+				"id": 1394,
 				"name": "HumanGL",
 				"xp": null
 			},
@@ -172,7 +172,7 @@
 				"xp": null
 			},
 			{
-				"id": 2087,
+				"id": 1855,
 				"name": "RT",
 				"xp": null
 			},

--- a/angular/src/assets/7-sec.json
+++ b/angular/src/assets/7-sec.json
@@ -192,7 +192,7 @@
 				"xp": null
 			},
 			{
-				"id": 2082,
+				"id": 1458,
 				"name": "DoomNukem",
 				"xp": null
 			},
@@ -212,7 +212,7 @@
 				"xp": null
 			},
 			{
-				"id": 2087,
+				"id": 1855,
 				"name": "RT",
 				"xp": null
 			},


### PR DESCRIPTION
I noticed that several project ids were incorrect in the `JSON` files used to retrieve intranet project data.
In my case, `HumanGL` was not marked as validated because of the incorrect project id. I corrected a few other ids.
You can test that the ids provided are correct by using `https://projects.intra.42.fr/projects/<project_id>`.

<img width="933" alt="Screenshot 2024-04-22 at 23 48 27" src="https://github.com/d-r-e/rncp/assets/91915468/f3e6bc01-7d4b-47f9-9372-aa358b309de5">
