### PR TITLE
Add new entry for Learn2Slither in 7-ai.json

### DIFF
--- a/angular/src/assets/7-ai.json
+++ b/angular/src/assets/7-ai.json
@@ -26,6 +26,11 @@
 				"xp": 9450
 			},
 			{
+				"id": 2551,
+				"name": "Learn2Slither",
+				"xp": 9450
+			},
+			{
 				"id": 1383,
 				"name": "Gomoku",
 				"xp": 25200


### PR DESCRIPTION
Resolve the missing 'Learn2Slither' project in the RNCP 7 AI branch.

```json
			{
				"id": 2551,
				"name": "Learn2Slither",
				"xp": 9450
			},
```