### PR TITLE
Fix OAuth callback, env alignment, asset loading, and RNCP7 security …

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 ### Development
 
 1. Edit `flask/.env` and set `CLIENT_ID`, `CLIENT_SECRET`, `SECOND_CLIENT_SECRET`, and `REDIRECT_URI`
-2. Replace the redirect url in the environment.ts
-3. Execute:
+2. Execute:
 
 ```bash
 docker compose run angular npm install
@@ -17,16 +16,76 @@ docker compose up -d
 
 ### Production
 
-0. Edit flask/.env
-1. Exec:
+0. Edit `flask/.env`
+1. Build Angular production image/assets:
 ```bash
 docker compose run angular sh -c "rm -rf node_modules && npm install && ng build"
 ```
 
-2. Uncomment the prod server on nginx.conf
-    2.1 Set SSL certificates
-3. Replace redirect url in the environment.ts
-4. Exec:
+2. Start production services:
 ```bash
 docker compose up -d nginx flask
 ```
+
+## Modifications réalisées (depuis la version de base)
+
+### 1) Correction OAuth callback (route Angular)
+- Ajout de la route `auth/callback/:campusId` en plus de `auth/callback`.
+- Fichier modifié: `angular/src/app/app.routes.ts`.
+- Impact: l'URL de callback `.../auth/callback/42` est maintenant correctement gérée côté front.
+
+### 2) Correction du composant login
+- Remplacement de l'import `environment.development` par `environment`.
+- Suppression de la navigation prématurée vers `/rncp` juste après réception du `code` OAuth.
+- Fichier modifié: `angular/src/app/login/login.component.ts`.
+- Impact: cohérence dev/prod et évite une navigation prématurée pendant l'authentification.
+
+### 3) Alignement des environnements Angular (dev/prod)
+- `environment.ts` et `environment.development.ts` contiennent maintenant:
+    - `production` explicite,
+    - `auth_url` complet,
+    - `redirect_uri` calculé dynamiquement via `window.location.origin`.
+- Fichiers modifiés:
+    - `angular/src/environments/environment.ts`
+    - `angular/src/environments/environment.development.ts`
+- Impact: plus besoin de modifier manuellement le redirect URI selon l'environnement.
+
+### 4) Correction chargement des blocs JSON (cause du rendu non fonctionnel)
+- Le chargement des assets passe par un chemin absolu `/assets/...`.
+- Ajout d'une gestion d'erreur pour vider proprement `blocks` si le JSON échoue.
+- Fichier modifié: `angular/src/app/path/path.component.ts`.
+- Impact: les blocs de projets (famine, pestilence, snow-crash, etc.) se chargent correctement.
+
+### 5) Alignement Nginx sur un rendu production
+- Activation du mode serveur statique Angular (`root /usr/share/nginx/html` + `try_files`).
+- Ajout de `include /etc/nginx/mime.types;`.
+- Fichier modifié: `nginx.conf`.
+- Impact: rendu local plus proche du site en production (build statique servi par Nginx).
+
+### 6) Port local unifié avec le callback OAuth
+- Mapping du port Nginx changé de `80:80` à `3000:80`.
+- Fichier modifié: `docker-compose.yml`.
+- Impact: cohérence avec le callback `http://localhost:3000/auth/callback/42`.
+
+## Résultat
+- Le parcours d'authentification fonctionne en local.
+- Les données de blocs/projets se chargent correctement.
+- Le rendu local est maintenant aligné sur le comportement attendu proche de la prod.
+
+## Suite des modifications (ordre des projets Security)
+
+### 7) Réorganisation de `blocks.security` dans `7-sec.json`
+- Réorganisation manuelle de la liste des projets dans `angular/src/assets/7-sec.json` (section `blocks.security`) pour respecter l'ordre souhaité des projets de l'outer core.
+- Les projets déjà présents ont conservé leurs informations existantes (`id`, `name`, `xp`) puis ont été replacés dans le nouvel ordre.
+- Les nouveaux projets ajoutés dans la liste ont été intégrés avec des `id` temporaires, puis les `xp` ont été renseignés.
+
+### 8) Projets retirés de la liste Security
+- Les projets suivants ne sont plus affichés dans la liste `blocks.security`:
+    - `Active Connect`
+    - `MicroForensX`
+    - `ActiveTechTales`
+- Raison: ces projets ont tout simplement disparu de l'Outer Core.
+
+### 9) Point d'attention cache navigateur
+- Après modification des assets JSON, l'ancien ordre peut rester visible à cause du cache navigateur.
+- En cas de décalage entre le fichier et l'affichage: forcer un rechargement (`Ctrl+Shift+R`) ou ouvrir en navigation privée.

--- a/angular/src/app/app.routes.ts
+++ b/angular/src/app/app.routes.ts
@@ -28,4 +28,8 @@ export const routes: Routes = [
 		path: 'auth/callback',
 		component: LoginComponent,
 	},
+	{
+		path: 'auth/callback/:campusId',
+		component: LoginComponent,
+	},
 ];

--- a/angular/src/app/login/login.component.ts
+++ b/angular/src/app/login/login.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { AuthService } from '../services/auth.service';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
@@ -13,14 +13,14 @@ import { TranslateModule } from '@ngx-translate/core';
 	styleUrl: './login.component.css',
 })
 export class LoginComponent implements OnInit {
-        auth_url = environment.auth_url;
-        repo_url = 'https://github.com/d-r-e/rncp';
+	auth_url = environment.auth_url;
+	repo_url = 'https://github.com/d-r-e/rncp';
 
 	constructor(
 		private route: ActivatedRoute,
 		private router: Router,
 		private authService: AuthService
-	) {}
+	) { }
 
 	ngOnInit(): void {
 		// Redirect to home if already logged in
@@ -32,7 +32,6 @@ export class LoginComponent implements OnInit {
 		this.route.queryParams.subscribe(params => {
 			if (params['code']) {
 				this.authService.login(params['code']);
-				this.router.navigate(['/rncp']);
 			}
 		});
 	}

--- a/angular/src/app/path/path.component.ts
+++ b/angular/src/app/path/path.component.ts
@@ -9,186 +9,191 @@ import { BlockComponent } from './block/block.component';
 
 // from https://42evaluators.com/calculator
 const levelsXp = [
-  0, 462, 2688, 5885, 11777, 29217, 46255, 63559, 74340, 85483, 95000, 105630,
-  124446, 145782, 169932, 197316, 228354, 263508, 303366, 348516, 399672, 457632,
-  523320, 597786, 682164, 777756, 886074, 1008798, 1147902, 1305486, 1484070];
+	0, 462, 2688, 5885, 11777, 29217, 46255, 63559, 74340, 85483, 95000, 105630,
+	124446, 145782, 169932, 197316, 228354, 263508, 303366, 348516, 399672, 457632,
+	523320, 597786, 682164, 777756, 886074, 1008798, 1147902, 1305486, 1484070];
 
 interface Internship {
-  name: string;
-  baseXP: number;
-  grade: number;
+	name: string;
+	baseXP: number;
+	grade: number;
 }
 
 @Component({
-  selector: 'app-path',
-  templateUrl: './path.component.html',
-  styleUrl: './path.component.css',
+	selector: 'app-path',
+	templateUrl: './path.component.html',
+	styleUrl: './path.component.css',
 })
 export class PathComponent implements OnInit {
-  events: number = 0;
-  rncp: number = 6;
-  blocks: Block[] = [];
-  projects: ProjectUser[] = [];
-  requiredLevel: number = 17;
-  requiredEvents: number = 10;
-  internships: number = 0;
-  requiredInternships: number = 2;
-  plannedInternships: Internship[] = [];
-  path: 'web' | 'apps' | 'sec' | 'ai' = 'ai';
-  selectedInternship?: Internship;  // To store the currently selected internship
-  selectedGrade: number = 100;  // Default grade value
-  inputValue: number = 100;
+	events: number = 0;
+	rncp: number = 6;
+	blocks: Block[] = [];
+	projects: ProjectUser[] = [];
+	requiredLevel: number = 17;
+	requiredEvents: number = 10;
+	internships: number = 0;
+	requiredInternships: number = 2;
+	plannedInternships: Internship[] = [];
+	path: 'web' | 'apps' | 'sec' | 'ai' = 'ai';
+	selectedInternship?: Internship;  // To store the currently selected internship
+	selectedGrade: number = 100;  // Default grade value
+	inputValue: number = 100;
 
-  @ViewChildren(BlockComponent) blockComponents!: QueryList<BlockComponent>;
+	@ViewChildren(BlockComponent) blockComponents!: QueryList<BlockComponent>;
 
-  availableInternships: Internship[] =
-    [
-      { name: 'Work Experience I', baseXP: 42000, grade: 100 },
-      { name: 'Work Experience II', baseXP: 63000, grade: 100 },
-    ]
-  showInternshipForm: boolean = false;
+	availableInternships: Internship[] =
+		[
+			{ name: 'Work Experience I', baseXP: 42000, grade: 100 },
+			{ name: 'Work Experience II', baseXP: 63000, grade: 100 },
+		]
+	showInternshipForm: boolean = false;
 
-  constructor(
-    private authService: AuthService,
-    private router: Router,
-    private http: HttpClient,
-    private translate: TranslateService
-  ) {
-    const internshipProjects = this.authService.getInternships();
-    this.availableInternships = this.availableInternships.filter(i=> !internshipProjects.find(p=> p.name === i.name));
-    this.internships = internshipProjects.length;
+	constructor(
+		private authService: AuthService,
+		private router: Router,
+		private http: HttpClient,
+		private translate: TranslateService
+	) {
+		const internshipProjects = this.authService.getInternships();
+		this.availableInternships = this.availableInternships.filter(i => !internshipProjects.find(p => p.name === i.name));
+		this.internships = internshipProjects.length;
 
-    this.authService.getEvents().subscribe((events: CursusEvent[]) => {
-      this.events = events.length;
-    });
+		this.authService.getEvents().subscribe((events: CursusEvent[]) => {
+			this.events = events.length;
+		});
 
-    if (this.authService.me) {
-      this.projects = this.authService.me.projects_users.filter(
-        (project: ProjectUser) =>
-          project.cursus_ids.includes(21) && project['validated?']
-      );
-    }
-  }
+		if (this.authService.me) {
+			this.projects = this.authService.me.projects_users.filter(
+				(project: ProjectUser) =>
+					project.cursus_ids.includes(21) && project['validated?']
+			);
+		}
+	}
 
-  ngOnInit(): void {
-    this.setRNCP(7);
-  }
+	ngOnInit(): void {
+		this.setRNCP(7);
+	}
 
-  loadData() {
-    this.http.get(`assets/${this.rncp}-${this.path}.json`).subscribe(response => {
-      this.blocks = response as Block[];
-    });
-  }
+	loadData() {
+		this.http.get<Block[]>(`/assets/${this.rncp}-${this.path}.json`).subscribe({
+			next: (response: Block[]) => {
+				this.blocks = response;
+			},
+			error: () => {
+				this.blocks = [];
+			},
+		});
+	}
 
-  onInputChange(event: Event): void {
-    const inputElement = event.target as HTMLInputElement;
-    const newValue = Number(inputElement.value);
-    this.selectedGrade = newValue;
-  }
+	onInputChange(event: Event): void {
+		const inputElement = event.target as HTMLInputElement;
+		const newValue = Number(inputElement.value);
+		this.selectedGrade = newValue;
+	}
 
-  selectInternship(internship: Internship) {
-    this.selectedInternship = internship;
-  }
+	selectInternship(internship: Internship) {
+		this.selectedInternship = internship;
+	}
 
-  addPlannedInternship() {
-    if (!this.selectedInternship) return;
-    if (this.selectedGrade < 100 || this.selectedGrade > 125) return;
-  
-    const existingInternship = this.plannedInternships.find(
-      i => i.name === this.selectedInternship?.name
-    );
-  
-    if (!existingInternship) {
-      this.plannedInternships.push({
-        ...this.selectedInternship,
-        grade: this.selectedGrade
-      });
-      this.updatePlannedXP();
-      this.internships++;
-    } else {
-      existingInternship.grade = this.selectedGrade;
-      this.updatePlannedXP();
-    }
-  
-    this.selectedInternship = undefined;
-    this.selectedGrade = 100;
-  }
+	addPlannedInternship() {
+		if (!this.selectedInternship) return;
+		if (this.selectedGrade < 100 || this.selectedGrade > 125) return;
 
-  updatePlannedXP() {
-    const totalPlannedXP = this.plannedInternships.reduce((total, internship) => {
-      const xp = internship.baseXP * (internship.grade ? internship.grade / 100 : 1);
-      return total + xp;
-    }, 0);
+		const existingInternship = this.plannedInternships.find(
+			i => i.name === this.selectedInternship?.name
+		);
 
-    // Here you could update your UI or any other relevant property with the calculated XP
-    console.log('Total Planned XP:', totalPlannedXP);
-  }
+		if (!existingInternship) {
+			this.plannedInternships.push({
+				...this.selectedInternship,
+				grade: this.selectedGrade
+			});
+			this.updatePlannedXP();
+			this.internships++;
+		} else {
+			existingInternship.grade = this.selectedGrade;
+			this.updatePlannedXP();
+		}
 
-  setRNCP(level: number) {
-    this.rncp = level;
-    this.requiredLevel = level == 6 ? 17 : 21;
-    this.requiredEvents = level == 6 ? 10 : 15;
-    this.path = level == 6 ? 'web' : 'sec';
-    this.loadData();
-  }
+		this.selectedInternship = undefined;
+		this.selectedGrade = 100;
+	}
 
-  setPath(path: 'web' | 'apps' | 'sec' | 'ai') {
-    this.path = path;
-    this.loadData();
-  }
+	updatePlannedXP() {
+		const totalPlannedXP = this.plannedInternships.reduce((total, internship) => {
+			const xp = internship.baseXP * (internship.grade ? internship.grade / 100 : 1);
+			return total + xp;
+		}, 0);
 
-  getLevel() {
-    return this.authService.getLevel();
-  }
+		// Here you could update your UI or any other relevant property with the calculated XP
+		console.log('Total Planned XP:', totalPlannedXP);
+	}
 
-  private getUniquePlannedProjectsXp(): number {
-    // Collect all planned projects from all blocks, deduplicated by project ID
-    const uniquePlannedProjects = new Map<number, number>(); // projectId -> XP
-    
-    // Iterate through all block components to get their planned projects
-    if (this.blockComponents) {
-      this.blockComponents.forEach((blockComponent: BlockComponent) => {
-        blockComponent.planned_projects.forEach((plannedProject: ProjectUser) => {
-          const projectId = plannedProject.project.id;
-          const projectXp = plannedProject.occurrence;
-          
-          // Store the maximum XP if the same project is planned with different grades
-          const currentXp = uniquePlannedProjects.get(projectId);
-          if (currentXp === undefined || projectXp > currentXp) {
-            uniquePlannedProjects.set(projectId, projectXp);
-          }
-        });
-      });
-    }
-    
-    // Sum up the XP from unique planned projects
-    return Array.from(uniquePlannedProjects.values()).reduce((acc, xp) => acc + xp, 0);
-  }
+	setRNCP(level: number) {
+		this.rncp = level;
+		this.requiredLevel = level == 6 ? 17 : 21;
+		this.requiredEvents = level == 6 ? 10 : 15;
+		this.path = level == 6 ? 'web' : 'sec';
+		this.loadData();
+	}
 
-  getPlannedLevel() {
-    const startLevel = this.getLevel();
-    
-    // Get deduplicated XP from all planned projects across blocks
-    let plannedXp = this.getUniquePlannedProjectsXp();
-    
-    // Add internship XP
-    plannedXp += this.plannedInternships.map((internship: Internship) => internship.baseXP * internship.grade / 100).reduce((acc, xp) => acc + xp, 0);
-    
-    const levelDown = Math.floor(startLevel);
-    const levelUp = Math.ceil(startLevel);
-    const levelXpTotal = levelsXp[levelUp] - levelsXp[levelDown];
-    const currentXp = levelsXp[levelDown] + (levelXpTotal * (startLevel - Math.floor(startLevel)));
+	setPath(path: 'web' | 'apps' | 'sec' | 'ai') {
+		this.path = path;
+		this.loadData();
+	}
 
-    let finalXp = currentXp + plannedXp;
+	getLevel() {
+		return this.authService.getLevel();
+	}
 
-    let i = 0;
-    for (; i < levelsXp.length; i++) {
-      if (levelsXp[i] > finalXp) break;
-    }
+	private getUniquePlannedProjectsXp(): number {
+		// Collect all planned projects from all blocks, deduplicated by project ID
+		const uniquePlannedProjects = new Map<number, number>(); // projectId -> XP
 
-    const maxXp = levelsXp[i] - levelsXp[i - 1];
-    finalXp = finalXp - levelsXp[i - 1];
+		// Iterate through all block components to get their planned projects
+		if (this.blockComponents) {
+			this.blockComponents.forEach((blockComponent: BlockComponent) => {
+				blockComponent.planned_projects.forEach((plannedProject: ProjectUser) => {
+					const projectId = plannedProject.project.id;
+					const projectXp = plannedProject.occurrence;
 
-    return i - 1 + (finalXp / maxXp);
-  }
+					// Store the maximum XP if the same project is planned with different grades
+					const currentXp = uniquePlannedProjects.get(projectId);
+					if (currentXp === undefined || projectXp > currentXp) {
+						uniquePlannedProjects.set(projectId, projectXp);
+					}
+				});
+			});
+		}
+
+		// Sum up the XP from unique planned projects
+		return Array.from(uniquePlannedProjects.values()).reduce((acc, xp) => acc + xp, 0);
+	}
+
+	getPlannedLevel() {
+		const startLevel = this.getLevel();
+
+		// Get deduplicated XP from all planned projects across blocks
+		let plannedXp = this.getUniquePlannedProjectsXp();
+
+		// Add internship XP
+		plannedXp += this.plannedInternships.map((internship: Internship) => internship.baseXP * internship.grade / 100).reduce((acc, xp) => acc + xp, 0);
+
+		const levelDown = Math.floor(startLevel);
+		const levelUp = Math.ceil(startLevel);
+		const levelXpTotal = levelsXp[levelUp] - levelsXp[levelDown];
+		const currentXp = levelsXp[levelDown] + (levelXpTotal * (startLevel - Math.floor(startLevel)));
+
+		let finalXp = currentXp + plannedXp;
+
+		let i = 0;
+		for (; i < levelsXp.length; i++) {
+			if (levelsXp[i] > finalXp) break;
+		}
+
+		const maxXp = levelsXp[i] - levelsXp[i - 1];
+		finalXp = finalXp - levelsXp[i - 1];
+
+		return i - 1 + (finalXp / maxXp);
+	}
 }

--- a/angular/src/assets/7-sec.json
+++ b/angular/src/assets/7-sec.json
@@ -6,34 +6,14 @@
 		"min_projects": 3,
 		"projects": [
 			{
-				"id": 1430,
-				"name": "famine",
+				"id": 39001,
+				"name": "cybersecurity",
 				"xp": 9450
-			},
-			{
-				"id": 1443,
-				"name": "pestilence",
-				"xp": 15750
 			},
 			{
 				"id": 1404,
 				"name": "snow-crash",
 				"xp": 9450
-			},
-			{
-				"id": 1840,
-				"name": "ft_malcolm",
-				"xp": 6000
-			},
-			{
-				"id": 1451,
-				"name": "ft_ssl_md5",
-				"xp": 9450
-			},
-			{
-				"id": 1405,
-				"name": "Darkly",
-				"xp": 6000
 			},
 			{
 				"id": 1417,
@@ -51,39 +31,64 @@
 				"xp": 11500
 			},
 			{
-				"id": 1447,
-				"name": "ft_shield",
-				"xp": 15750
-			},
-			{
-				"id": 1419,
-				"name": "Woody Woodpacker",
-				"xp": 9450
-			},
-			{
-				"id": 2346,
-				"name": "Piscine Cybersecurity",
-				"xp": 0
-			},
-			{
 				"id": 2393,
 				"name": "UnleashTheBox",
 				"xp": 15750
 			},
 			{
-				"id": 2395,
-				"name": "Active Connect",
-				"xp": 15750
+				"id": 39002,
+				"name": "tinky-winkey",
+				"xp": 16800
 			},
 			{
-				"id": 2527,
-				"name": "MicroForensX",
+				"id": 39003,
+				"name": "dr-quine",
+				"xp": 2520
+			},
+			{
+				"id": 1419,
+				"name": "woody-woodpacker",
 				"xp": 9450
 			},
 			{
-				"id": 2529,
-				"name": "ActiveTechTales",
-				"xp": 15750 
+				"id": 1447,
+				"name": "ft_shield",
+				"xp": 15750
+			},
+			{
+				"id": 1430,
+				"name": "famine",
+				"xp": 9450
+			},
+			{
+				"id": 1443,
+				"name": "pestilence",
+				"xp": 15750
+			},
+			{
+				"id": 39004,
+				"name": "war",
+				"xp": 35700
+			},
+			{
+				"id": 39005,
+				"name": "death",
+				"xp": 35700
+			},
+			{
+				"id": 1840,
+				"name": "ft_malcolm",
+				"xp": 6000
+			},
+			{
+				"id": 1400,
+				"name": "ft_nmap",
+				"xp": 15750
+			},
+			{
+				"id": 1405,
+				"name": "Darkly",
+				"xp": 6000
 			}
 		]
 	},
@@ -192,7 +197,7 @@
 				"xp": 22450
 			},
 			{
-				 "id": 1458,
+				"id": 1458,
 				"name": "Doom Nukem",
 				"xp": 15750
 			},
@@ -276,23 +281,23 @@
 			},
 			{
 				"id": 2520,
-				"name":"Active Discovery",
-				"xp": 15750 
+				"name": "Active Discovery",
+				"xp": 15750
 			},
 			{
 				"id": 2521,
 				"name": "Automatic Directory",
-				"xp": 9450 
+				"xp": 9450
 			},
 			{
 				"id": 2522,
 				"name": "Administrative Directory",
-				"xp":9450 
+				"xp": 9450
 			},
 			{
 				"id": 2523,
 				"name": "Accessible Directory",
-				"xp": 9450 
+				"xp": 9450
 			}
 		]
 	}

--- a/angular/src/environments/environment.development.ts
+++ b/angular/src/environments/environment.development.ts
@@ -1,6 +1,8 @@
+const redirectUri = encodeURIComponent(`${window.location.origin}/auth/callback/42`);
+
 export const environment = {
 	production: false,
 	auth_url:
-		'https://api.intra.42.fr/oauth/authorize?client_id=<CLIENT_UUID>&redirect_uri=<REDIRECT_URI>&response_type=code',
+		`https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-7282b484449a021720b0c6dbd86b212e0d9cd7980348786659e3ebf8f81cf718&redirect_uri=${redirectUri}&response_type=code`,
 	api_url: 'https://api.intra.42.fr',
 };

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -1,1 +1,8 @@
-export const environment = {};
+const redirectUri = encodeURIComponent(`${window.location.origin}/auth/callback/42`);
+
+export const environment = {
+	production: true,
+	auth_url:
+		`https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-7282b484449a021720b0c6dbd86b212e0d9cd7980348786659e3ebf8f81cf718&redirect_uri=${redirectUri}&response_type=code`,
+	api_url: 'https://api.intra.42.fr',
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       context: .
       dockerfile: nginx.Dockerfile
     ports:
-      - "80:80"
+      - "3000:80"
       - "127.0.0.1:4200:4200"
     depends_on:
       - flask

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,7 @@ http {
 
     server {
         listen 80;
+        include /etc/nginx/mime.types;
         server_name localhost;
         server_tokens off;
 
@@ -15,39 +16,11 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # angular dev
         location / {
-            proxy_pass http://angular:4200;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            # for websockets:
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            
+            root /usr/share/nginx/html;
+            index index.html index.htm;
+            try_files $uri $uri/ /index.html;
         }
 
     }
-
-    # server {
-    #     listen 80;
-    #     # regular mime types
-    #     include /etc/nginx/mime.types;
-    #     server_name localhost;
-    #     server_tokens off;
-
-    #     location /api {
-    #         proxy_pass http://flask:5000;
-    #         proxy_set_header Host $host;
-    #         proxy_set_header X-Real-IP $remote_addr;
-    #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     }
-
-    #     location / {
-    #         root /usr/share/nginx/html;
-    #         index index.html index.htm;
-    #         try_files $uri $uri/ /index.html;
-    #     }
-    # }
 }


### PR DESCRIPTION
This PR fixes local/production inconsistencies (auth, assets, routing) and updates the blocks.security project list to match the current Outer Core order.
Local rendering now shows the correct blocks in the correct order, and browser cache was identified as a source of confusion during validation.

Detailed changes (before → after → reason):

[app.routes.ts:32](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Before: only auth/callback route existed.
After: added auth/callback/:campusId.
Reason: support the real callback path /auth/callback/42.

[login.component.ts:3](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [login.component.ts:34](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Before: imported environment.development and triggered a premature navigation to /rncp.
After: import environment and call login(code) without immediate redirect.
Reason: keep dev/prod behavior consistent and avoid OAuth navigation race conditions.

[path.component.ts:78-85](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Before: relative asset loading without error handling.
After: absolute /assets/... path and fallback blocks = [] on request failure.
Reason: make project block rendering reliable.

[environment.ts:1-7](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [environment.development.ts:1-7](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Before: incomplete/placeholder configuration.
After: dynamic redirect_uri using window.location.origin and explicit auth_url.
Reason: remove manual environment-specific reconfiguration.

[nginx.conf:8](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [nginx.conf:20-22](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Before: proxied to ng serve.
After: static Angular serving (root + try_files) plus mime types include.
Reason: align local rendering with production behavior.

[docker-compose.yml:27](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Before: 80:80.
After: 3000:80.
Reason: match OAuth redirect URI on localhost:3000.

[7-sec.json:4-85](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Before: old security order with obsolete projects.
After: requested order (cybersecurity, snow-crash, …, Darkly) with updated XP values.
Reason: align the list with the current Outer Core.

note:
Active Connect, MicroForensX, and ActiveTechTales were removed because they are no longer part of the Outer Core.